### PR TITLE
Prepare GitHub Pages export and simplify ML-focused design

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build static site
+        run: yarn export
+
+      - name: Disable Jekyll
+        run: touch out/.nojekyll
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,3 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
-
-# vercel
-.vercel

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![ReactJS Resume Website Template](resume-screenshot.jpg?raw=true 'ReactJS Resume Website Template')
 
-### View a [live demo here.](https://reactresume.com)
+### View the site at [asgundogdu.github.io](https://asgundogdu.github.io)
 
 #### If this template has helped you and you'd like to support my work, feel free to [♥️ Sponsor](https://github.com/sponsors/tbakerx) the project
 
@@ -44,12 +44,14 @@ Due to the variety of options available for contact form providers, I've hooked 
 
 Of course, all of the code is there and nothing is hidden from you so if you would like to make any other styling/data changes, feel free!
 
-### 7. Deploy to GitHub Pages and enjoy your new Resume Website
+### 7. Deploy to GitHub Pages
 
-This project is configured for static export so it can be hosted on GitHub Pages without relying on Vercel. To publish your site:
+This project is configured for static export and GitHub Pages deployment through GitHub Actions. The intended default Pages URL is `https://asgundogdu.github.io`.
 
-1. Run `yarn export` (or `npm run export`) to generate the static site in the `/out` directory.
-2. Commit and push the `/out` folder to a branch named `gh-pages`.
-3. In your repository settings on GitHub, enable GitHub Pages to serve from the `gh-pages` branch (root folder).
+To publish the site:
 
-After a minute or two, your site will be live at `https://<your-username>.github.io`.
+1. Make sure the repository is named `asgundogdu.github.io`; otherwise GitHub serves it as a project site under `https://asgundogdu.github.io/<repo-name>/`.
+2. In repository settings, set GitHub Pages to deploy from GitHub Actions.
+3. Merge changes into `main`.
+
+The workflow builds the static site into `/out`, adds `.nojekyll`, and deploys the artifact to GitHub Pages. No custom domain or external hosting provider is required.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Due to the variety of options available for contact form providers, I've hooked 
 
 Of course, all of the code is there and nothing is hidden from you so if you would like to make any other styling/data changes, feel free!
 
-### 7. Deploy to Vercel and enjoy your new Resume Website
+### 7. Deploy to GitHub Pages and enjoy your new Resume Website
 
-Deploying your new site to Vercel is simple, and can be done by following their guide [here.](https://vercel.com/guides/deploying-nextjs-with-vercel) When you're all done and the build succeeds, you should be given a url for your live site, go there and you'll see your new personal resume website! Congratulations!
+This project is configured for static export so it can be hosted on GitHub Pages without relying on Vercel. To publish your site:
+
+1. Run `yarn export` (or `npm run export`) to generate the static site in the `/out` directory.
+2. Commit and push the `/out` folder to a branch named `gh-pages`.
+3. In your repository settings on GitHub, enable GitHub Pages to serve from the `gh-pages` branch (root folder).
+
+After a minute or two, your site will be live at `https://<your-username>.github.io`.

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
 module.exports = {
-  siteUrl: 'reactresume.com',
+  siteUrl: 'https://asgundogdu.github.io',
   exclude: ['/404*', '/500*'],
   transform: async (config, path) => {
     return {

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,8 @@
 /* eslint-env node */
 
 // https://github.com/vercel/next.js/blob/master/packages/next/next-server/server/config.ts
+const isGithubPages = process.env.GITHUB_PAGES === 'true';
+
 const nextConfig = {
   webpack: config => {
     const oneOfRule = config.module.rules.find(rule => rule.oneOf);
@@ -24,12 +26,14 @@ const nextConfig = {
     multipass: true,
     plugins: ['removeDimensions'],
   },
-  strictMode: true,
-  swcMinify: true,
-  trailingSlash: false,
+  assetPrefix: isGithubPages ? './' : undefined,
+  trailingSlash: true,
   images: {
+    unoptimized: true,
     domains: ['images.unsplash.com', 'source.unsplash.com'],
   },
+  strictMode: true,
+  swcMinify: true,
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,5 @@
 /* eslint-env node */
 
-// https://github.com/vercel/next.js/blob/master/packages/next/next-server/server/config.ts
-const isGithubPages = process.env.GITHUB_PAGES === 'true';
-
 const nextConfig = {
   webpack: config => {
     const oneOfRule = config.module.rules.find(rule => rule.oneOf);
@@ -26,7 +23,11 @@ const nextConfig = {
     multipass: true,
     plugins: ['removeDimensions'],
   },
-  assetPrefix: isGithubPages ? './' : undefined,
+  experimental: {
+    images: {
+      unoptimized: true,
+    },
+  },
   trailingSlash: true,
   images: {
     unoptimized: true,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "yarn compile && yarn next build",
+    "export": "yarn compile && yarn next build && yarn next export",
     "clean": "rm -rf build-tsc .next",
     "compile": "yarn run -T tsc --build --verbose",
     "dev": "yarn compile && yarn next dev",
@@ -72,5 +73,5 @@
   "bugs": {
     "url": "https://github.com/asgundogdu/ahmetg.github.io/issues"
   },
-  "homepage": "https://github.com/asgundogdu/ahmetg.github.io#readme"
+  "homepage": "https://ahmetg.github.io"
 }

--- a/package.json
+++ b/package.json
@@ -73,5 +73,5 @@
   "bugs": {
     "url": "https://github.com/asgundogdu/ahmetg.github.io/issues"
   },
-  "homepage": "https://ahmetg.github.io"
+  "homepage": "https://asgundogdu.github.io"
 }

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -5,6 +5,8 @@ import {memo} from 'react';
 
 import {HomepageMeta} from '../../data/dataDef';
 
+const siteUrl = 'https://asgundogdu.github.io';
+
 const Page: NextPage<HomepageMeta> = memo(({children, title, description}) => {
   const {asPath: pathname} = useRouter();
 
@@ -15,7 +17,7 @@ const Page: NextPage<HomepageMeta> = memo(({children, title, description}) => {
         <meta content={description} name="description" />
 
         {/* several domains list the same content, make sure google knows we mean this one. */}
-        <link href={`https://reactresume.com${pathname}`} key="canonical" rel="canonical" />
+        <link href={`${siteUrl}${pathname}`} key="canonical" rel="canonical" />
 
         <link href="/favicon.ico" rel="icon" sizes="any" />
         <link href="/icon.svg" rel="icon" type="image/svg+xml" />
@@ -25,7 +27,7 @@ const Page: NextPage<HomepageMeta> = memo(({children, title, description}) => {
         {/* Open Graph : https://ogp.me/ */}
         <meta content={title} property="og:title" />
         <meta content={description} property="og:description" />
-        <meta content={`https://reactresume.com${pathname}`} property="og:url" />
+        <meta content={`${siteUrl}${pathname}`} property="og:url" />
 
         {/* Twitter: https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup */}
         <meta content={title} name="twitter:title" />

--- a/src/components/Sections/About.tsx
+++ b/src/components/Sections/About.tsx
@@ -8,26 +8,28 @@ import Section from '../Layout/Section';
 const About: FC = memo(() => {
   const {profileImageSrc, description, aboutItems} = aboutData;
   return (
-    <Section className="bg-neutral-800" sectionId={SectionId.About}>
-      <div className={classNames('grid grid-cols-1 gap-y-4', {'md:grid-cols-4': !!profileImageSrc})}>
+    <Section className="bg-neutral-50" sectionId={SectionId.About}>
+      <div className={classNames('grid grid-cols-1 gap-y-6', {'md:grid-cols-4': !!profileImageSrc})}>
         {!!profileImageSrc && (
           <div className="col-span-1 flex justify-center md:justify-start">
-            <div className="relative h-24 w-24 overflow-hidden rounded-xl md:h-32 md:w-32">
+            <div className="relative h-28 w-28 overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm md:h-32 md:w-32">
               <Image alt="about-me-image" layout="fill" objectFit="cover" src={profileImageSrc} />
             </div>
           </div>
         )}
         <div className={classNames('col-span-1 flex flex-col gap-y-6', {'md:col-span-3': !!profileImageSrc})}>
           <div className="flex flex-col gap-y-2">
-            <h2 className="text-2xl font-bold text-white">About me</h2>
-            <p className="prose prose-sm text-gray-300 sm:prose-base">{description}</p>
+            <h2 className="text-2xl font-semibold text-neutral-900">About me</h2>
+            <p className="prose prose-neutral prose-sm text-neutral-700 sm:prose-base">{description}</p>
           </div>
           <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {aboutItems.map(({label, text, Icon}, idx) => (
-              <li className="col-span-1 flex  items-start gap-x-2" key={idx}>
-                {Icon && <Icon className="h-5 w-5 text-white" />}
-                <span className="text-sm font-bold text-white">{label}:</span>
-                <span className=" text-sm text-gray-300">{text}</span>
+              <li className="col-span-1 flex items-start gap-x-3 rounded-lg border border-neutral-200 bg-white p-3 shadow-sm" key={idx}>
+                {Icon && <Icon className="h-5 w-5 text-sky-700" />}
+                <div className="flex flex-col text-sm">
+                  <span className="font-semibold text-neutral-900">{label}</span>
+                  <span className="text-neutral-600">{text}</span>
+                </div>
               </li>
             ))}
           </ul>

--- a/src/components/Sections/Contact/ContactForm.tsx
+++ b/src/components/Sections/Contact/ContactForm.tsx
@@ -41,7 +41,7 @@ const ContactForm: FC = memo(() => {
   );
 
   const inputClasses =
-    'bg-neutral-700 border-0 focus:border-0 focus:outline-none focus:ring-1 focus:ring-orange-600 rounded-md placeholder:text-neutral-400 placeholder:text-sm text-neutral-200 text-sm';
+    'rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-800 placeholder:text-neutral-400 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200';
 
   return (
     <form className="grid min-h-[320px] grid-cols-1 gap-y-4" method="POST" onSubmit={handleSendMessage}>
@@ -66,7 +66,7 @@ const ContactForm: FC = memo(() => {
       />
       <button
         aria-label="Submit contact form"
-        className="w-max rounded-full border-2 border-orange-600 bg-stone-900 px-4 py-2 text-sm font-medium text-white shadow-md outline-none hover:bg-stone-800 focus:ring-2 focus:ring-orange-600 focus:ring-offset-2 focus:ring-offset-stone-800"
+        className="w-max rounded-full border border-sky-600 bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2"
         type="submit">
         Send Message
       </button>

--- a/src/components/Sections/Contact/index.tsx
+++ b/src/components/Sections/Contact/index.tsx
@@ -26,19 +26,22 @@ const ContactValueMap: Record<ContactType, ContactValue> = {
 const Contact: FC = memo(() => {
   const {headerText, description, items} = contact;
   return (
-    <Section className="bg-neutral-800" sectionId={SectionId.Contact}>
+    <Section className="bg-neutral-50" sectionId={SectionId.Contact}>
       <div className="flex flex-col gap-y-6">
-        <div className="flex flex-col gap-6 md:flex-row md:items-center">
-          <MailIcon className="hidden h-16 w-16 text-white md:block" />
-          <h2 className="text-2xl font-bold text-white">{headerText}</h2>
+        <div className="flex flex-col gap-4 md:flex-row md:items-center">
+          <MailIcon className="hidden h-14 w-14 text-sky-700 md:block" />
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-700">Contact</p>
+            <h2 className="text-2xl font-semibold text-neutral-900">{headerText}</h2>
+          </div>
         </div>
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           <div className="order-2 col-span-1 md:order-1 ">
             <ContactForm />
           </div>
           <div className="order-1 col-span-1 flex flex-col gap-y-4 md:order-2">
-            <p className="prose leading-6 text-neutral-300">{description}</p>
-            <dl className="flex flex-col space-y-4 text-base text-neutral-500 sm:space-y-2">
+            <p className="prose prose-neutral leading-6 text-neutral-700">{description}</p>
+            <dl className="flex flex-col space-y-3 text-base text-neutral-600 sm:space-y-2">
               {items.map(({type, text, href}) => {
                 const {Icon, srLabel} = ContactValueMap[type];
                 return (
@@ -47,13 +50,13 @@ const Contact: FC = memo(() => {
                     <dd className="flex items-center">
                       <a
                         className={classNames(
-                          '-m-2 flex rounded-md p-2 text-neutral-300 hover:text-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500',
-                          {'hover:text-white': href},
+                          '-m-2 flex rounded-md p-2 text-neutral-700 transition-colors hover:text-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-600',
+                          {'hover:text-neutral-900': href},
                         )}
                         href={href}
                         target="_blank">
-                        <Icon aria-hidden="true" className="h-4 w-4 flex-shrink-0 text-neutral-100 sm:h-5 sm:w-5" />
-                        <span className="ml-3 text-sm sm:text-base">{text}</span>
+                        <Icon aria-hidden="true" className="h-4 w-4 flex-shrink-0 text-sky-700 sm:h-5 sm:w-5" />
+                        <span className="ml-3 text-sm text-neutral-800 sm:text-base">{text}</span>
                       </a>
                     </dd>
                   </div>

--- a/src/components/Sections/Footer.tsx
+++ b/src/components/Sections/Footer.tsx
@@ -5,19 +5,19 @@ import {SectionId} from '../../data/data';
 import Socials from '../Socials';
 
 const Footer: FC = memo(() => (
-  <div className="relative bg-neutral-900 px-4 pb-6 pt-12 sm:px-8 sm:pt-14 sm:pb-8">
-    <div className="absolute inset-x-0 -top-4 flex justify-center sm:-top-6">
+  <div className="relative border-t border-neutral-200 bg-white px-4 pb-8 pt-10 sm:px-8">
+    <div className="absolute inset-x-0 -top-5 flex justify-center">
       <a
-        className="rounded-full bg-neutral-100 p-1 ring-white ring-offset-2 ring-offset-gray-700/80 focus:outline-none focus:ring-2 sm:p-2"
+        className="rounded-full bg-white p-2 shadow-sm ring-1 ring-neutral-200 hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-sky-600"
         href={`/#${SectionId.Hero}`}>
-        <ChevronUpIcon className="h-6 w-6 bg-transparent sm:h-8 sm:w-8" />
+        <ChevronUpIcon className="h-6 w-6 text-neutral-800 sm:h-7 sm:w-7" />
       </a>
     </div>
-    <div className="flex flex-col items-center gap-y-6">
-      <div className="flex gap-x-4 text-neutral-500">
+    <div className="flex flex-col items-center gap-y-4">
+      <div className="flex gap-x-4 text-neutral-600">
         <Socials />
       </div>
-      <span className="text-sm text-neutral-700">© Copyright 2022 Tim Baker</span>
+      <span className="text-sm text-neutral-600">© Copyright 2022 Tim Baker</span>
     </div>
   </div>
 ));

--- a/src/components/Sections/Header.tsx
+++ b/src/components/Sections/Header.tsx
@@ -33,11 +33,11 @@ const Header: FC = memo(() => {
 const DesktopNav: FC<{navSections: SectionId[]; currentSection: SectionId | null}> = memo(
   ({navSections, currentSection}) => {
     const baseClass =
-      '-m-1.5 p-1.5 rounded-md font-bold first-letter:uppercase hover:transition-colors hover:duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 sm:hover:text-orange-500 text-neutral-100';
-    const activeClass = classNames(baseClass, 'text-orange-500');
-    const inactiveClass = classNames(baseClass, 'text-neutral-100');
+      '-m-1.5 rounded-md p-1.5 font-semibold first-letter:uppercase text-neutral-700 hover:text-sky-700 hover:transition-colors hover:duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-600';
+    const activeClass = classNames(baseClass, 'text-sky-700');
+    const inactiveClass = classNames(baseClass, 'text-neutral-600');
     return (
-      <header className="fixed top-0 z-50 hidden w-full bg-neutral-900/50 p-4 backdrop-blur sm:block" id={headerID}>
+      <header className="fixed top-0 z-50 hidden w-full border-b border-neutral-200 bg-white/90 p-4 backdrop-blur sm:block" id={headerID}>
         <nav className="flex justify-center gap-x-8">
           {navSections.map(section => (
             <NavItem
@@ -63,14 +63,14 @@ const MobileNav: FC<{navSections: SectionId[]; currentSection: SectionId | null}
     }, [isOpen]);
 
     const baseClass =
-      'p-2 rounded-md first-letter:uppercase transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500';
-    const activeClass = classNames(baseClass, 'bg-neutral-900 text-white font-bold');
-    const inactiveClass = classNames(baseClass, 'text-neutral-200 font-medium');
+      'p-2 rounded-md first-letter:uppercase transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-600';
+    const activeClass = classNames(baseClass, 'bg-sky-50 text-sky-800 font-bold');
+    const inactiveClass = classNames(baseClass, 'text-neutral-700 font-medium');
     return (
       <>
         <button
           aria-label="Menu Button"
-          className="fixed top-2 right-2 z-40 rounded-md bg-orange-500 p-2 ring-offset-gray-800/60 hover:bg-orange-400 focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 sm:hidden"
+          className="fixed top-2 right-2 z-40 rounded-md bg-sky-600 p-2 shadow-sm ring-offset-white hover:bg-sky-700 focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-sky-600 focus-visible:ring-offset-2 sm:hidden"
           onClick={toggleOpen}>
           <MenuAlt3Icon className="h-8 w-8 text-white" />
           <span className="sr-only">Open sidebar</span>
@@ -85,7 +85,7 @@ const MobileNav: FC<{navSections: SectionId[]; currentSection: SectionId | null}
               leave="transition-opacity ease-linear duration-300"
               leaveFrom="opacity-100"
               leaveTo="opacity-0">
-              <Dialog.Overlay className="fixed inset-0 bg-stone-900 bg-opacity-75" />
+              <Dialog.Overlay className="fixed inset-0 bg-stone-900 bg-opacity-30" />
             </Transition.Child>
             <Transition.Child
               as={Fragment}
@@ -95,8 +95,8 @@ const MobileNav: FC<{navSections: SectionId[]; currentSection: SectionId | null}
               leave="transition ease-in-out duration-300 transform"
               leaveFrom="translate-x-0"
               leaveTo="-translate-x-full">
-              <div className="relative w-4/5 bg-stone-800">
-                <nav className="mt-5 flex flex-col gap-y-2 px-2">
+              <div className="relative w-4/5 bg-white shadow-lg">
+                <nav className="mt-5 flex flex-col gap-y-2 px-4 py-2">
                   {navSections.map(section => (
                     <NavItem
                       activeClass={activeClass}

--- a/src/components/Sections/Hero.tsx
+++ b/src/components/Sections/Hero.tsx
@@ -1,4 +1,3 @@
-import {ChevronDownIcon} from '@heroicons/react/outline';
 import classNames from 'classnames';
 import Image from 'next/image';
 import {FC, memo} from 'react';
@@ -8,49 +7,50 @@ import Section from '../Layout/Section';
 import Socials from '../Socials';
 
 const Hero: FC = memo(() => {
-  const {imageSrc, name, description, actions} = heroData;
+  const {imageSrc, name, description, actions, highlights} = heroData;
 
   return (
-    <Section noPadding sectionId={SectionId.Hero}>
-      <div className="relative flex h-screen w-screen items-center justify-center">
-        <Image
-          alt={`${name}-image`}
-          className="absolute z-0"
-          layout="fill"
-          objectFit="cover"
-          placeholder="blur"
-          priority
-          src={imageSrc}
-        />
-        <div className="z-10  max-w-screen-lg px-4 lg:px-0">
-          <div className="flex flex-col items-center gap-y-6 rounded-xl bg-gray-800/40 p-6 text-center shadow-lg backdrop-blur-sm">
-            <h1 className="text-4xl font-bold text-white sm:text-5xl lg:text-7xl">{name}</h1>
-            {description}
-            <div className="flex gap-x-4 text-neutral-100">
-              <Socials />
-            </div>
-            <div className="flex w-full justify-center gap-x-4">
-              {actions.map(({href, text, primary, Icon}) => (
-                <a
-                  className={classNames(
-                    'flex gap-x-2 rounded-full border-2 bg-none py-2 px-4 text-sm font-medium text-white ring-offset-gray-700/80 hover:bg-gray-700/80 focus:outline-none focus:ring-2 focus:ring-offset-2 sm:text-base',
-                    primary ? 'border-orange-500 ring-orange-500' : 'border-white ring-white',
-                  )}
-                  href={href}
-                  key={text}>
-                  {text}
-                  {Icon && <Icon className="h-5 w-5 text-white sm:h-6 sm:w-6" />}
-                </a>
+    <Section className="bg-white" sectionId={SectionId.Hero}>
+      <div className="grid items-center gap-10 md:grid-cols-[1.2fr,0.8fr]">
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-700 sm:text-sm">Machine Learning Engineer</p>
+            <h1 className="text-4xl font-semibold text-neutral-900 sm:text-5xl lg:text-6xl">{name}</h1>
+            <div className="prose prose-neutral max-w-none text-base text-neutral-700 sm:text-lg">{description}</div>
+          </div>
+          {highlights && (
+            <div className="flex flex-wrap gap-2">
+              {highlights.map(item => (
+                <span
+                  className="rounded-full bg-neutral-100 px-3 py-1 text-sm font-medium text-neutral-700 ring-1 ring-neutral-200"
+                  key={item}>
+                  {item}
+                </span>
               ))}
             </div>
+          )}
+          <div className="flex flex-wrap gap-3 text-neutral-800">
+            <Socials />
+          </div>
+          <div className="flex flex-wrap gap-3">
+            {actions.map(({href, text, primary, Icon}) => (
+              <a
+                className={classNames(
+                  'flex items-center gap-x-2 rounded-full px-4 py-2 text-sm font-semibold transition-colors duration-300 sm:text-base',
+                  primary
+                    ? 'bg-sky-600 text-white shadow-sm hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600'
+                    : 'border border-neutral-300 bg-white text-neutral-800 hover:bg-neutral-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-400',
+                )}
+                href={href}
+                key={text}>
+                {text}
+                {Icon && <Icon className="h-5 w-5" />}
+              </a>
+            ))}
           </div>
         </div>
-        <div className="absolute inset-x-0 bottom-6 flex justify-center">
-          <a
-            className="rounded-full bg-white p-1 ring-white ring-offset-2 ring-offset-gray-700/80 focus:outline-none focus:ring-2 sm:p-2"
-            href={`/#${SectionId.About}`}>
-            <ChevronDownIcon className="h-5 w-5 bg-transparent sm:h-6 sm:w-6" />
-          </a>
+        <div className="relative mx-auto h-64 w-64 overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-50 shadow-sm sm:h-72 sm:w-72 md:h-80 md:w-80">
+          <Image alt={`${name}-image`} layout="fill" objectFit="cover" placeholder="blur" priority src={imageSrc} />
         </div>
       </div>
     </Section>

--- a/src/components/Sections/Resume/index.tsx
+++ b/src/components/Sections/Resume/index.tsx
@@ -20,8 +20,15 @@ const Resume: FC = memo(() => {
           ))}
         </ResumeSection>
         <ResumeSection title="Skills">
-                 <p className="pb-8">Python, Java, Scala - TensorFlow, Keras, PyTorch, OpenCV, PySpark, Neo4j, Apache Spark/Beam, Scio - Google Dataflow/AI Platform, AWS</p>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <div className="space-y-2 rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
+              <h3 className="text-lg font-semibold text-neutral-900">Modeling & Evaluation</h3>
+              <p className="text-sm text-neutral-700">PyTorch, TensorFlow, Ray RLlib, LangChain, HuggingFace, vector search (Faiss, Pinecone), prompt evaluation, offline/online experimentation</p>
+            </div>
+            <div className="space-y-2 rounded-xl border border-neutral-200 bg-white p-4 shadow-sm">
+              <h3 className="text-lg font-semibold text-neutral-900">MLOps & Data</h3>
+              <p className="text-sm text-neutral-700">Python, Scala, Kubernetes, Kubeflow, Airflow, Spark/Beam, MLflow, Weights & Biases, feature stores, CI/CD for ML, AWS/GCP</p>
+            </div>
           </div>
         </ResumeSection>
       </div>

--- a/src/components/Socials.tsx
+++ b/src/components/Socials.tsx
@@ -8,7 +8,7 @@ const Socials: FC = memo(() => {
       {socialLinks.map(({label, Icon, href}) => (
         <a
           aria-label={label}
-          className="-m-1.5 rounded-md p-1.5 transition-all duration-300 hover:text-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500  sm:-m-3 sm:p-3"
+          className="-m-1.5 rounded-md p-1.5 transition-all duration-300 hover:text-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-600  sm:-m-3 sm:p-3"
           href={href}
           key={label}>
           <Icon className="h-5 w-5 align-baseline sm:h-6 sm:w-6" />

--- a/src/data/data.tsx
+++ b/src/data/data.tsx
@@ -21,8 +21,8 @@ import {
  * Page meta data
  */
 export const homePageMeta: HomepageMeta = {
-  title: "Ahmet Gundogdu WebPage",
-  description: "my personal webpage",
+  title: "Ahmet Gundogdu | Machine Learning Engineer",
+  description: "ML engineer focused on reliable robotics, large-scale training, and modern MLOps.",
 };
 
 /**
@@ -46,26 +46,20 @@ export const heroData: Hero = {
   name: `Ahmet Gundogdu.`,
   description: (
     <>
-      <p className="prose-sm text-stone-200 sm:prose-base lg:prose-lg">
-        I am a{" "}
-        <strong className="text-stone-100">Machine Learning Engineer</strong>,
-        currently focusing on Large-Scale Imitation Learning for
-        Robotic Mobile manipulation at Boston Dynamics AI Institute. My work
-        involves developing Imitation Learning models for robotic arm control
-        and leading the development of a new library on top of the Ray framework
-        to enhance machine learning training and deployment infrastructure.
-        Previously, I was at Spotify working on AI-powered music recommendations
-        and have co-hosted a podcast on artificial intelligence and machine
-        learning called Veri Tezgahi. I hold a master's degree in Computer &
-        Information Science from Northeastern University, specializing in
-        machine learning and natural language processing.
+      <p className="prose-sm text-stone-700 sm:prose-base lg:prose-lg">
+        I am a <strong className="text-stone-900">Machine Learning Engineer</strong> building reliable, production-grade AI systems. At Boston Dynamics AI Institute I focus on imitation learning for mobile manipulation, shaping policy learning pipelines that move from simulation to hardware with reproducibility and observability in mind.
       </p>
-      <p className="prose-sm text-stone-200 sm:prose-base lg:prose-lg">
-        I co-host a podcast on artificial intelligence and machine learning
-        called Veri Tezgahi. (Currently, only available in Turkish)
+      <p className="prose-sm text-stone-700 sm:prose-base lg:prose-lg">
+        I previously worked on large-scale recommendation systems at Spotify and now spend most of my time combining LLM tooling, vector search, and robotics control stacks. I also co-host Veri Tezgahi, an AI podcast for Turkish-speaking engineers.
       </p>
     </>
   ),
+  highlights: [
+    "LLM evaluation, safety, and retrieval (LangChain, Faiss, OpenAI API)",
+    "Distributed training and reinforcement learning with PyTorch + Ray",
+    "Experiment tracking and observability with MLflow & Weights & Biases",
+    "GPU-first pipelines on Kubernetes for robotics and MLOps",
+  ],
   actions: [
     {
       href: "https://open.spotify.com/show/6xh1JvolfduK8j5sb1WnoC",
@@ -85,7 +79,8 @@ export const heroData: Hero = {
  */
 export const aboutData: About = {
   profileImageSrc: profilepic,
-  description: `I am a machine learning enthusiast who loves to build stuff and an outdoor adventurer.`,
+  description:
+    `I design ML systems end-to-end—from data curation to deployment—so research ideas can ship quickly without sacrificing reliability. Outside work I enjoy trail running, tinkering with hardware projects, and sharing lessons learned with the ML community.`,
   aboutItems: [
     { label: "Location", text: "Boston, MA", Icon: MapIcon },
     { label: "Study", text: "Northeastern University", Icon: AcademicCapIcon },
@@ -102,10 +97,10 @@ export const experience: TimelineItem[] = [
     title: "Machine Learning Engineer",
     content: (
       <p>
-        Focused on Large-Scale Imitation Learning for Robotic Mobile
-        manipulation. Developed an Imitation Learning model for robotic arm
-        control and led the development of a new library on top of the Ray
-        framework to enhance ML training and deployment infrastructure.
+        Lead large-scale imitation learning for mobile manipulation, pairing
+        PyTorch + Ray with strong evaluation harnesses to push policies from
+        simulation into hardware. Building reproducible training and rollout
+        tooling with telemetry, experiment tracking, and continuous validation.
       </p>
     ),
   },
@@ -115,10 +110,10 @@ export const experience: TimelineItem[] = [
     title: "Machine Learning Engineer",
     content: (
       <p>
-        Worked on representation learning for Spotify users and tracks using
-        large scale deep neural networks and music description platform using
-        Kubeflow ML infrastructure to automatically describe and tag content for
-        retrieval by multiple teams within the company.
+        Built recommendation and content understanding models using large-scale
+        representation learning. Shipped Kubeflow-based pipelines, feature
+        stores, and vector search services to keep ranking models fresh and
+        observable.
       </p>
     ),
   },
@@ -128,9 +123,8 @@ export const experience: TimelineItem[] = [
     title: "Data Science (Co-op)",
     content: (
       <p>
-        Carried out research and development of a tool that recognizes film
-        entities in podcast audio via fuzzy matching and supervised learning,
-        resulting in publication at KDD 2018.
+        Prototyped an audio entity recognition pipeline using fuzzy matching and
+        supervised learning, which led to a KDD 2018 publication.
       </p>
     ),
   },
@@ -140,9 +134,9 @@ export const experience: TimelineItem[] = [
     title: "Data Scientist",
     content: (
       <p>
-        Designed an RNN-based anomaly detection system to capture car accidents
-        by using time series data taken from city sensors with 95% accuracy,
-        outperforming the heuristic baseline.
+        Designed an RNN-based anomaly detection system for city sensor data
+        (95% accuracy) and automated the rollout so incident alerts were
+        shipped to operators in real time.
       </p>
     ),
   },
@@ -156,8 +150,8 @@ export const education: TimelineItem[] = [
     content: (
       <p>
         {" "}
-        Research Areas: NLP, Recommendation Systems, Information Retrieval,
-        Distributed Systems.
+        Research Areas: NLP, recommendation systems, information retrieval,
+        distributed systems.
       </p>
     ),
   },
@@ -178,7 +172,7 @@ Contact section
 export const contact: ContactSection = {
   headerText: "Get in touch.",
   description:
-    "Here is a good spot for a message to your readers to let them know how best to reach out to you.",
+    "Reach out if you're looking to collaborate on ML platforms, robotics learning loops, or applied LLM projects. I'm always open to swapping notes with fellow engineers.",
   items: [
     {
       type: ContactType.Email,

--- a/src/data/dataDef.ts
+++ b/src/data/dataDef.ts
@@ -25,6 +25,7 @@ export interface Hero {
   name: string;
   description: JSX.Element;
   actions: HeroActionItem[];
+  highlights?: string[];
 }
 
 interface HeroActionItem {


### PR DESCRIPTION
## Summary
- deploy the static Next.js export with GitHub Pages Actions instead of Vercel or a committed `gh-pages` branch
- target the default GitHub Pages URL, `https://asgundogdu.github.io`, with no custom-domain or CNAME configuration
- update homepage, sitemap, canonical, and Open Graph URLs away from the old template/custom-domain values
- keep the ML-focused content/design refresh from the original PR and add Next 12 export compatibility for unoptimized images

## Testing
- `npx -p node@16 -p yarn@1.22.22 yarn export`
- verified `out/index.html`, `out/404/index.html`, `out/_next`, and `out/.nojekyll`
- `git diff --check`

## Notes
- The workflow is pinned to Node 16 because this older Next 12.1 image pipeline fails under newer Node runtimes during static export.
- For the exact default URL `https://asgundogdu.github.io`, the repository should be named `asgundogdu.github.io`; otherwise GitHub Pages will publish it as a project site under `https://asgundogdu.github.io/<repo-name>/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925d87da4488329854d37d5815246d3)